### PR TITLE
Fix #2 Ensure all watches removed after non-blocking alts read

### DIFF
--- a/src/cues/queue.clj
+++ b/src/cues/queue.clj
@@ -539,12 +539,12 @@
 
 (defn- alts
   [tailers]
-  (reduce
-   (fn [_ t]
+  (some
+   (fn [t]
      (when-let [msg (read t)]
-       (rm-watches t)
-       (reduced [t msg])))
-   nil
+       (doseq [t* tailers]
+         (rm-watches t*))
+       [t msg]))
    tailers))
 
 (defn alts!!
@@ -1651,10 +1651,10 @@
    (send! graph nil msg))
   ([{p      :processors
      config :config} source msg]
-   (let [id        (or source (:source config))
-         {:keys [type impl]
-          :as   s} (get p id)]
-     (if (and s (= type ::source))
+   (let [id           (or source (:source config))
+         {impl :impl
+          type :type} (get p id)]
+     (if (= type ::source)
        (write (:appender @impl) msg)
        (throw (ex-info "Could not find source" {:id id}))))))
 


### PR DESCRIPTION
Fixes #2 

Updates `cues.queue/alts` to remove all watches on a successful read. Failing to remove watches incurs a minor alts performance penalty in cases where tailers are repeatedly being created and destroyed. Does not affect behaviour of queues and tailers otherwise.